### PR TITLE
Fix chrono min version to 0.4.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ syn = "2.0"
 
 actix-multipart = "0.6"
 garde-actix-web = "0.6"
-chrono = "0.4"
+chrono = "0.4.20"
 garde = { version = "0.18", features = ["derive", "serde"] }
 rust_decimal = "1"
 serde_qs = "0.12"


### PR DESCRIPTION
Fix chrono min version to fix [RUSTSEC-2020-0159](https://rustsec.org/advisories/RUSTSEC-2020-0159.html)