### PR TITLE
Ensure compatibility with preserve_order feature of schemars

### DIFF
--- a/apistos-gen-test/Cargo.toml
+++ b/apistos-gen-test/Cargo.toml
@@ -22,7 +22,8 @@ futures-core = { workspace = true }
 apistos = { path = "../apistos", features = ["multipart", "uuid"] }
 apistos-core = { path = "../apistos-core", version = "0.2.1" }
 apistos-gen = { path = "../apistos-gen", version = "0.2.1" }
-schemars = { workspace = true }
+# we use the "preserve_order" feature from schemars here following https://github.com/netwo-io/apistos/pull/78
+schemars = { workspace = true, features = ["preserve_order"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }

--- a/apistos-gen-test/src/tests/api_component_derive.rs
+++ b/apistos-gen-test/src/tests/api_component_derive.rs
@@ -519,31 +519,6 @@ fn api_component_derive_named_enums() {
   );
 
   let (child_schema_name, child_schema) = name_child_schemas.first().expect("missing child schema");
-  assert_eq!(child_schema_name, "ActiveOrInactiveQuery");
-  assert_schema(&child_schema.clone());
-  let json = serde_json::to_value(child_schema).expect("Unable to serialize as Json");
-  assert_json_eq!(
-    json,
-    json!({
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "id": {
-          "format": "uint32",
-          "minimum": 0.0,
-          "type": "integer"
-        }
-      },
-      "required": [
-        "description",
-        "id"
-      ],
-      "type": "object"
-    })
-  );
-
-  let (child_schema_name, child_schema) = name_child_schemas.last().expect("missing child schema");
   assert_eq!(child_schema_name, "KindQuery");
   assert_schema(&child_schema.clone());
   let json = serde_json::to_value(child_schema).expect("Unable to serialize as Json");
@@ -578,6 +553,31 @@ fn api_component_derive_named_enums() {
           "type": "object"
         }
       ]
+    })
+  );
+
+  let (child_schema_name, child_schema) = name_child_schemas.last().expect("missing child schema");
+  assert_eq!(child_schema_name, "ActiveOrInactiveQuery");
+  assert_schema(&child_schema.clone());
+  let json = serde_json::to_value(child_schema).expect("Unable to serialize as Json");
+  assert_json_eq!(
+    json,
+    json!({
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "description",
+        "id"
+      ],
+      "type": "object"
     })
   );
 }

--- a/apistos-gen/src/internal/schemas.rs
+++ b/apistos-gen/src/internal/schemas.rs
@@ -39,7 +39,7 @@ impl ToTokens for Schemas {
         schemars::schema::Schema::Object(sch_obj) => {
           if let Some(obj) = sch_obj.object.as_mut() {
             if obj.properties.len() == 1 {
-              if let Some((prop_name, _)) = obj.properties.first_key_value() {
+              if let Some((prop_name, _)) = obj.properties.iter().next() {
                 #update_metadata_title;
               }
             } else if let Some(enum_values) = obj.properties.iter_mut().find_map(|(_, p)| match p {


### PR DESCRIPTION
When using the `preserve_order` feature of `schemars`, `BTreeMap` is internally replaced with an `IndexMap`, which does not have the `first_key_value()` method. This PR uses `iter().next()`, which has the same semantics, but is available both in `BTreeMap` and `IndexMap`.