### PR TITLE
Add actix-web-grants feature to apistos

### DIFF
--- a/apistos/Cargo.toml
+++ b/apistos/Cargo.toml
@@ -57,6 +57,9 @@ lab_query = ["apistos-core/lab_query"]
 # actix garde feature
 garde = ["apistos-core/garde"]
 
+# actix web grants feature
+actix-web-grants = ["apistos-core/actix-web-grants"]
+
 # extra types related features
 chrono = ["apistos-core/chrono"]
 multipart = ["apistos-core/multipart"]


### PR DESCRIPTION
apistos-core have actix-web-grants feature but there was no way to enable from apistos crate. I added option for enabling actix-web-grants feature in apistos-core.