### PR TITLE
Fix #138

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ serde_json = "1"
 syn = "2.0"
 
 actix-multipart = "0.6"
+actix-session = "0.10"
 garde-actix-web = "0.9"
 chrono = "0.4.20"
 garde = { version = "0.20", features = ["derive", "serde"] }

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ For a complete example, see [the sample petstore](https://github.com/netwo-io/ap
 | `actix` (default)  | Enables documenting types from `actix`                                   |                                                                 |
 | `lab_query`        | Enables documenting `actix_web_lab::extract::Query`                      | [`actix-web-lab`](https://crates.io/crates/actix-web-lab)       |
 | `garde`            | Enables input validation through `garde`                                 | [`garde`](https://crates.io/crates/garde)                       |
+| `actix-session`    | Enables documenting types from `actix-session`                           | [`actix-session`](https://crates.io/crates/actix-session)       |
 | `actix-web-grants` | Enables support for `actix-web-grants`                                   | [`actix-web-grants`](https://crates.io/crates/actix-web-grants) |
 | `rapidoc`          | Enables RapiDoc to expose the generated openapi file                     |                                                                 |
 | `redoc`            | Enables Redoc to expose the generated openapi file                       |                                                                 |

--- a/apistos-core/Cargo.toml
+++ b/apistos-core/Cargo.toml
@@ -21,6 +21,7 @@ actix-web = { workspace = true, optional = true }
 actix-web-lab = { workspace = true, optional = true }
 actix-web-grants = { workspace = true, optional = true }
 actix-multipart = { workspace = true, optional = true }
+actix-session = { workspace = true, optional = true }
 garde-actix-web = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
 rust_decimal = { workspace = true, optional = true }
@@ -54,6 +55,7 @@ garde = ["actix", "dep:garde-actix-web"]
 chrono = ["dep:chrono", "schemars/chrono"]
 multipart = ["actix", "dep:serde", "dep:actix-multipart"]
 rust_decimal = ["dep:rust_decimal", "schemars/rust_decimal"]
+actix-session = ["actix", "dep:serde", "dep:actix-session"]
 uuid = ["dep:uuid", "schemars/uuid1"]
 url = ["dep:url", "schemars/url"]
 extras = ["chrono", "multipart", "rust_decimal", "uuid", "url"]

--- a/apistos-core/src/components/mod.rs
+++ b/apistos-core/src/components/mod.rs
@@ -8,4 +8,6 @@ pub mod json;
 pub mod multipart;
 #[cfg(feature = "actix")]
 pub mod parameters;
+#[cfg(feature = "actix-session")]
+pub mod session;
 pub mod simple;

--- a/apistos-core/src/components/session.rs
+++ b/apistos-core/src/components/session.rs
@@ -1,0 +1,40 @@
+use crate::ApiComponent;
+use apistos_models::paths::{Parameter, ParameterDefinition, ParameterIn, RequestBody};
+use apistos_models::reference_or::ReferenceOr;
+use schemars::schema::{InstanceType, Schema, SchemaObject, SingleOrVec, StringValidation};
+
+impl ApiComponent for actix_session::Session {
+  fn required() -> bool {
+    true
+  }
+
+  fn child_schemas() -> Vec<(String, ReferenceOr<Schema>)> {
+    vec![]
+  }
+
+  fn raw_schema() -> Option<ReferenceOr<Schema>> {
+    Some(ReferenceOr::Object(Schema::Object(SchemaObject {
+      instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::String))),
+      string: Some(Box::new(StringValidation::default())),
+      ..Default::default()
+    })))
+  }
+
+  fn schema() -> Option<(String, ReferenceOr<Schema>)> {
+    None
+  }
+
+  fn request_body() -> Option<RequestBody> {
+    None
+  }
+
+  fn parameters() -> Vec<Parameter> {
+    vec![Parameter {
+      name: "id".to_string(), // from default actix-session's CookieConfiguration
+      _in: ParameterIn::Cookie,
+      required: Some(true),
+      definition: Self::raw_schema().map(ParameterDefinition::Schema),
+      ..Default::default()
+    }]
+  }
+}


### PR DESCRIPTION
Add missing implementation for actix_session::Session. 
⚠️ Cookie name is 'id' and is not configurable (based on actix_session default configuration) !