### PR TITLE
Fix enum tagged v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ proc-macro2 = "1.0"
 proc-macro-error2 = "2.0"
 quote = "1.0"
 regex = ">=1.5.5"
-schemars = { version = "1.0.0-alpha.17", features = ["chrono04", "uuid1", "url2", "rust_decimal1"] }
+schemars = { version = "=1.0.0-alpha.15", features = ["chrono04", "uuid1", "url2", "rust_decimal1"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 syn = "2.0"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ carpenters, craftsmen, metallurgy ... which can also be considered by some as th
 
 ```toml
 [dependencies]
-schemars = "1.0.0-alpha.17"
+schemars = "=1.0.0-alpha.15"
 apistos = "1.0.0-pre-release.10"
 ```
 

--- a/apistos-gen-test/src/tests/api_component_derive_oas_3_0.rs
+++ b/apistos-gen-test/src/tests/api_component_derive_oas_3_0.rs
@@ -942,31 +942,37 @@ fn api_component_derive_named_enums_deep() {
     json!({
       "oneOf": [
         {
-          "title": "type",
+          "title": "something",
           "type": "object",
           "properties": {
             "type": {
               "type": "string",
               "const": "something"
+            },
+            "name": {
+              "type": "string"
             }
           },
-          "$ref": "#/components/schemas/TestStuff",
           "required": [
-            "type"
+            "type",
+            "name"
           ]
         },
         {
-          "title": "type",
+          "title": "other",
           "type": "object",
           "properties": {
             "type": {
               "type": "string",
               "const": "other"
+            },
+            "name": {
+              "type": "string"
             }
           },
-          "$ref": "#/components/schemas/TestStuff",
           "required": [
-            "type"
+            "type",
+            "name"
           ]
         }
       ]

--- a/apistos-gen-test/src/tests/api_component_derive_oas_3_1.rs
+++ b/apistos-gen-test/src/tests/api_component_derive_oas_3_1.rs
@@ -679,8 +679,7 @@ fn api_component_derive_named_enums_documented() {
 fn api_component_derive_named_tagged_enums() {
   #[derive(Serialize, Debug, ApiComponent, JsonSchema)]
   #[cfg_attr(test, derive(Deserialize))]
-  #[serde(tag = "kind")]
-  #[serde(rename_all = "snake_case")]
+  #[serde(tag = "kind", rename_all = "snake_case")]
   pub(crate) enum TestStruct {
     Variant1 {
       expiration: DateTime<Utc>,
@@ -760,16 +759,14 @@ fn api_component_derive_named_enums_deep() {
   }
 
   #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, ApiComponent, JsonSchema)]
-  #[schemars(rename_all = "snake_case")]
-  #[schemars(tag = "type")]
+  #[serde(rename_all = "snake_case", tag = "type")]
   pub(crate) enum Level4Query {
     Something(TestStuff),
     Other(TestStuff),
   }
 
   #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, ApiComponent, JsonSchema)]
-  #[schemars(rename_all = "snake_case")]
-  #[schemars(tag = "type", content = "c")]
+  #[serde(rename_all = "snake_case", tag = "type", content = "c")]
   pub(crate) enum Level4BisQuery {
     Something(TestStuff),
     Other(TestStuff),

--- a/apistos-gen-test/src/tests/api_component_derive_oas_3_1.rs
+++ b/apistos-gen-test/src/tests/api_component_derive_oas_3_1.rs
@@ -756,6 +756,7 @@ fn api_component_derive_named_enums_deep() {
   #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, ApiComponent, JsonSchema)]
   pub(crate) struct TestStuff {
     pub(crate) name: String,
+    pub(crate) plop: String,
   }
 
   #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, ApiComponent, JsonSchema)]
@@ -962,31 +963,45 @@ fn api_component_derive_named_enums_deep() {
     json!({
       "oneOf": [
         {
-          "title": "type",
+          "title": "something",
           "type": "object",
           "properties": {
             "type": {
               "type": "string",
               "const": "something"
+            },
+            "name": {
+              "type": "string"
+            },
+            "plop": {
+              "type": "string"
             }
           },
-          "$ref": "#/components/schemas/TestStuff",
           "required": [
-            "type"
+            "type",
+            "name",
+            "plop"
           ]
         },
         {
-          "title": "type",
+          "title": "other",
           "type": "object",
           "properties": {
             "type": {
               "type": "string",
               "const": "other"
+            },
+            "name": {
+              "type": "string"
+            },
+            "plop": {
+              "type": "string"
             }
           },
-          "$ref": "#/components/schemas/TestStuff",
           "required": [
-            "type"
+            "type",
+            "name",
+            "plop"
           ]
         }
       ]

--- a/apistos-models/README.md
+++ b/apistos-models/README.md
@@ -27,7 +27,7 @@ These models are not linked to any web framework.
 
 ```toml
 [dependencies]
-schemars = "1.0.0-alpha.17"
+schemars = "=1.0.0-alpha.15"
 apistos-models = "1.0.0-pre-release.10"
 ```
 

--- a/apistos-models/src/schema.rs
+++ b/apistos-models/src/schema.rs
@@ -17,9 +17,9 @@ impl ApistosSchema {
       None => Self(schema),
       Some(obj) => {
         // set title for each one_of if not set
-        if let Some(one_of) = obj.get_mut("oneOf").and_then(|v| v.as_array_mut()) {
-          Self::set_title_for_enum_variants(one_of);
-        }
+        // if let Some(one_of) = obj.get_mut("oneOf").and_then(|v| v.as_array_mut()) {
+        //   Self::set_title_for_enum_variants(one_of);
+        // }
 
         // remove definitions from schema
         Self::remove_definition_from_schema(obj, &oas_version.get_schema_settings().into_generator());

--- a/apistos-models/src/schema.rs
+++ b/apistos-models/src/schema.rs
@@ -261,31 +261,37 @@ mod test {
       json!({
         "oneOf": [
           {
-            "title": "type",
+            "title": "Test",
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
                 "const": "Test"
+              },
+              "name": {
+                "type": "string"
               }
             },
-            "$ref": "#/components/schemas/TestStruct",
             "required": [
-              "type"
+              "type",
+              "name"
             ]
           },
           {
-            "title": "type",
+            "title": "Test2",
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
                 "const": "Test2"
+              },
+              "surname": {
+                "type": "string"
               }
             },
-            "$ref": "#/components/schemas/TestStruct2",
             "required": [
-              "type"
+              "type",
+              "surname"
             ]
           }
         ]
@@ -408,31 +414,37 @@ mod test {
       json!({
         "oneOf": [
           {
-            "title": "type",
+            "title": "Test",
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
                 "const": "Test"
+              },
+              "name": {
+                "type": "string"
               }
             },
-            "$ref": "#/$defs/TestStruct",
             "required": [
-              "type"
+              "type",
+              "name"
             ]
           },
           {
-            "title": "type",
+            "title": "Test2",
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
                 "const": "Test2"
+              },
+              "surname": {
+                "type": "string"
               }
             },
-            "$ref": "#/$defs/TestStruct2",
             "required": [
-              "type"
+              "type",
+              "surname"
             ]
           }
         ]

--- a/apistos-rapidoc/README.md
+++ b/apistos-rapidoc/README.md
@@ -24,7 +24,7 @@ This crate is exposed through Apistos `rapidoc` feature.
 
 ```toml
 [dependencies]
-schemars = "1.0.0-alpha.17"
+schemars = "=1.0.0-alpha.15"
 apistos = { version = "1.0.0-pre-release.10", feature = ["rapidoc"] }
 ```
 

--- a/apistos-redoc/README.md
+++ b/apistos-redoc/README.md
@@ -24,7 +24,7 @@ This crate is exposed through Apistos `redoc` feature.
 
 ```toml
 [dependencies]
-schemars = "1.0.0-alpha.17"
+schemars = "=1.0.0-alpha.15"
 apistos = { version = "1.0.0-pre-release.10", feature = ["redoc"] }
 ```
 

--- a/apistos-scalar/README.md
+++ b/apistos-scalar/README.md
@@ -24,7 +24,7 @@ This crate is exposed through Apistos `scalar` feature.
 
 ```toml
 [dependencies]
-schemars = "1.0.0-alpha.17"
+schemars = "=1.0.0-alpha.15"
 apistos = { version = "1.0.0-pre-release.10", feature = ["scalar"] }
 ```
 

--- a/apistos-shuttle/README.md
+++ b/apistos-shuttle/README.md
@@ -22,7 +22,7 @@ This crate allows you to run an actix-web server documented with Apistos on [Shu
 
 ```toml
 [dependencies]
-schemars = "1.0.0-alpha.17"
+schemars = "=1.0.0-alpha.15"
 apistos = { version = "1.0.0-pre-release.10" }
 apistos-shuttle = { version = "1.0.0-pre-release.10" }
 ```

--- a/apistos-swagger-ui/README.md
+++ b/apistos-swagger-ui/README.md
@@ -24,7 +24,7 @@ This crate is exposed through Apistos `swagger-ui` feature.
 
 ```toml
 [dependencies]
-schemars = "1.0.0-alpha.17"
+schemars = "=1.0.0-alpha.15"
 apistos = { version = "1.0.0-pre-release.10", feature = ["swagger-ui"] }
 ```
 

--- a/apistos/src/lib.rs
+++ b/apistos/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! schemars = "1.0.0-alpha.17"
+//! schemars = "=1.0.0-alpha.15"
 //! apistos = "1.0.0-pre-release.10"
 //! ```
 //!

--- a/examples/petstore/Cargo.toml
+++ b/examples/petstore/Cargo.toml
@@ -12,7 +12,7 @@ env_logger = "0.11"
 futures = "0.3"
 num-traits = "0.2"
 rust_decimal = "1"
-schemars = { version = "1.0.0-alpha.17", features = ["chrono04", "uuid1", "url2", "rust_decimal1"] }
+schemars = { version = "=1.0.0-alpha.15", features = ["chrono04", "uuid1", "url2", "rust_decimal1"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_qs = { version = "0.14", features = ["actix4"] }
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/examples/simple-shuttle-rs/Cargo.toml
+++ b/examples/simple-shuttle-rs/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Netwo <oss@netwo.com>"]
 actix-web = "4"
 apistos = { path = "../../apistos", features = ["extras", "qs_query", "rapidoc", "redoc", "swagger-ui"] }
 apistos-shuttle = { path = "../../apistos-shuttle" }
-schemars = { version = "1.0.0-alpha.17", features = ["chrono04", "uuid1", "url2", "rust_decimal1"] }
+schemars = { version = "=1.0.0-alpha.15", features = ["chrono04", "uuid1", "url2", "rust_decimal1"] }
 serde = { version = "1.0", features = ["derive"] }
 shuttle-runtime = { version = "0.53", default-features = false }
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/examples/simple-todo-macros/Cargo.toml
+++ b/examples/simple-todo-macros/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Netwo <oss@netwo.com>"]
 [dependencies]
 actix-web = "4"
 apistos = { path = "../../apistos", features = ["extras", "qs_query", "rapidoc", "redoc", "scalar", "swagger-ui", "actix-web-macros"] }
-schemars = { version = "1.0.0-alpha.17", features = ["chrono04", "uuid1", "url2", "rust_decimal1"] }
+schemars = { version = "=1.0.0-alpha.15", features = ["chrono04", "uuid1", "url2", "rust_decimal1"] }
 serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 

--- a/examples/simple-todo/Cargo.toml
+++ b/examples/simple-todo/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Netwo <oss@netwo.com>"]
 [dependencies]
 actix-web = "4"
 apistos = { path = "../../apistos", features = ["extras", "qs_query", "rapidoc", "redoc", "scalar", "swagger-ui"] }
-schemars = { version = "1.0.0-alpha.17", features = ["chrono04", "uuid1", "url2", "rust_decimal1"] }
+schemars = { version = "=1.0.0-alpha.15", features = ["chrono04", "uuid1", "url2", "rust_decimal1"] }
 serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 


### PR DESCRIPTION
Revert schemars to alpha-15 for now as it seems that most of the tooling is struggling with `$ref` adjacent to `properties` for internally tagged enum variants.