### PR TITLE
Implement ApiComponent for &'static str and &'static [u8]

### DIFF
--- a/apistos-core/src/components/simple.rs
+++ b/apistos-core/src/components/simple.rs
@@ -27,6 +27,8 @@ macro_rules! simple_modifier {
 }
 
 simple_modifier!(char);
+simple_modifier!(&'static str);
+simple_modifier!(&'static [u8]);
 simple_modifier!(String);
 simple_modifier!(bool);
 simple_modifier!(f32);


### PR DESCRIPTION
I feel like ApiComponent should be implemented for everything that implements [Responder in actix_web](https://docs.rs/actix-web/latest/actix_web/trait.Responder.html#foreign-impls)

I don't know if this affects any of the other web service compatibility implementations, but please suggest any fixes to this as needed.

The primary issue is that I tried to use #[api_operation] on a very primitive `fn() -> &'static str` handler implementation, which is not possible currently.