### PR TITLE
Improve documentation of apistos-swagger-ui

### DIFF
--- a/apistos-swagger-ui/README.md
+++ b/apistos-swagger-ui/README.md
@@ -30,6 +30,17 @@ schemars = { package = "apistos-schemars", version = "0.8" }
 apistos = { version = "0.5", features = ["swagger-ui"] }
 ```
 
+### Usage
+To use this feature replace your
+```
+.build("/openapi.json")
+```
+with
+```
+.build_with("/openapi.json", BuildConfig::default().with(SwaggerUIConfig::new(&"/swagger-ui")))
+```
+This then serves your api using swagger-ui at /swagger-ui on your server
+
 ### About us
 
 apistos is provided by [Netwo](https://www.netwo.io).

--- a/apistos-swagger-ui/README.md
+++ b/apistos-swagger-ui/README.md
@@ -27,7 +27,7 @@ This crate is exposed through Apistos `swagger-ui` feature.
 #schemars = "0.8"
 # sadly we currently rely on a fork to fix multiple flatten for enums, related PR can be found here: https://github.com/GREsau/schemars/pull/264
 schemars = { package = "apistos-schemars", version = "0.8" }
-apistos = { version = "0.5", feature = ["swagger-ui"] }
+apistos = { version = "0.5", features = ["swagger-ui"] }
 ```
 
 ### About us


### PR DESCRIPTION
Fixes a small but hard to notice typo in the example Cargo.toml and also add an example that shows how to use the feature.