### PR TITLE
Support for global security from Spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "apistos",
     "apistos-core",

--- a/apistos-gen-test/src/tests/api_operation.rs
+++ b/apistos-gen-test/src/tests/api_operation.rs
@@ -1679,3 +1679,115 @@ fn api_operation_actix_web_grant() {
     })
   );
 }
+
+#[test]
+#[allow(dead_code)]
+fn api_operation_no_security() {
+  /// Add a new pet to the store
+  /// Plop
+  #[api_operation(no_security)]
+  pub(crate) async fn test(
+    _body: Json<test_models::Test>,
+  ) -> Result<Json<test_models::TestResult>, test_models::ErrorResponse> {
+    Ok(Json(test_models::TestResult { id: 0 }))
+  }
+
+  let operation = __openapi_test::operation();
+  let operation = serde_json::to_value(operation).expect("Unable to serialize as Json");
+
+  assert_json_eq!(
+    operation,
+    json!({
+      "deprecated": false,
+      "description": "Plop",
+      "requestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Test"
+            }
+          }
+        },
+        "required": true
+      },
+      "responses": {
+        "200": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestResult"
+              }
+            }
+          },
+          "description": ""
+        },
+        "405": {
+          "description": "Invalid input"
+        }
+      },
+      "security": [],
+      "summary": "Add a new pet to the store"
+    })
+  );
+}
+
+#[test]
+#[allow(dead_code)]
+fn api_operation_no_security_with_optional_key() {
+  /// Add a new pet to the store
+  /// Plop
+  #[api_operation(no_security)]
+  pub(crate) async fn test(
+    _body: Json<test_models::Test>,
+    _key: Option<test_models::ApiKey>,
+  ) -> Result<Json<test_models::TestResult>, test_models::MultipleErrorResponse> {
+    Ok(Json(test_models::TestResult { id: 0 }))
+  }
+
+  let operation = __openapi_test::operation();
+  let operation = serde_json::to_value(operation).expect("Unable to serialize as Json");
+
+  assert_json_eq!(
+    operation,
+    json!({
+      "deprecated": false,
+      "description": "Plop",
+      "requestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Test"
+            }
+          }
+        },
+        "required": true
+      },
+      "responses": {
+        "200": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestResult"
+              }
+            }
+          },
+          "description": ""
+        },
+        "401": {
+          "description": "Unauthorized"
+        },
+        "403": {
+          "description": "Forbidden"
+        },
+        "404": {
+          "description": "Not Found"
+        },
+        "405": {
+          "description": "Method Not Allowed"
+        }
+      },
+      "security": [],
+      "summary": "Add a new pet to the store"
+    })
+  );
+}

--- a/apistos-gen/src/internal/mod.rs
+++ b/apistos-gen/src/internal/mod.rs
@@ -87,6 +87,7 @@ pub(crate) fn gen_open_api_impl(
         }
       }),
       tags: &operation_attribute.tags,
+      no_security: operation_attribute.no_security,
       scopes: operation_attribute.scopes,
       error_codes: &operation_attribute.error_codes,
       consumes: operation_attribute.consumes.as_ref(),

--- a/apistos-gen/src/internal/operation.rs
+++ b/apistos-gen/src/internal/operation.rs
@@ -12,6 +12,7 @@ pub(crate) struct Operation<'a> {
   pub(crate) summary: Option<&'a String>,
   pub(crate) description: Option<&'a str>,
   pub(crate) tags: &'a [String],
+  pub(crate) no_security: bool,
   pub(crate) scopes: BTreeMap<String, Vec<String>>,
   pub(crate) error_codes: &'a [u16],
   pub(crate) consumes: Option<&'a String>,
@@ -31,6 +32,11 @@ impl ToTokens for Operation<'_> {
       .deprecated
       .map(|deprecated| quote!(Some(#deprecated)))
       .unwrap_or_else(|| quote!(None));
+    let no_security = if self.no_security {
+      quote!(true)
+    } else {
+      quote!(false)
+    };
     let summary = match self.summary {
       None => quote!(),
       Some(s) => {
@@ -136,8 +142,10 @@ impl ToTokens for Operation<'_> {
         let securities = {
           #security
         };
-        if !securities.is_empty() {
-          operation_builder.security = securities;
+        if #no_security {
+          operation_builder.security = Some(vec![]);
+        } else if !securities.is_empty() {
+          operation_builder.security = Some(securities);
         }
 
         operation_builder.operation_id = #operation_id;

--- a/apistos-gen/src/internal/security/mod.rs
+++ b/apistos-gen/src/internal/security/mod.rs
@@ -36,11 +36,11 @@ impl ToTokens for Security<'_> {
       let mut securities = vec![];
       let needed_scopes: std::collections::BTreeMap<String, Vec<String>> = #scopes
       #(
-        if !<#args>::required() {
-          needs_empty_security = true;
-        }
         let mut security_requirements = vec![];
         if let Some(security_requirement_name) = <#args>::security_requirement_name() {
+          if !<#args>::required() {
+            needs_empty_security = true;
+          }
           let scopes: Vec<String> = needed_scopes.get(&security_requirement_name).cloned().unwrap_or_default();
           security_requirements.push(apistos::security::SecurityRequirement {
             requirements: std::collections::BTreeMap::from_iter(vec![(security_requirement_name, scopes)]),

--- a/apistos-gen/src/lib.rs
+++ b/apistos-gen/src/lib.rs
@@ -523,6 +523,7 @@ pub fn derive_api_error(input: TokenStream) -> TokenStream {
 ///   - `summary = "..."` an optional summary
 ///   - `description = "..."` an optional description
 ///   - `tag = "..."` an optional list of tags associated with this operation (define tag multiple times to add to the list)
+///   - `no_security` a bool allowing to override any top-level security declaration for this operation, resulting in an empty security requirement
 ///   - `security_scope(...)` an optional list representing which security scopes apply for a given operation with
 ///       - `name = "..."` a mandatory name referencing one of the security definitions
 ///       - `scope(...)` a list of scopes applying to this operation

--- a/apistos-gen/src/lib.rs
+++ b/apistos-gen/src/lib.rs
@@ -634,6 +634,15 @@ pub fn derive_api_error(input: TokenStream) -> TokenStream {
 ///   Ok(CreatedJson(body.0))
 /// }
 /// ```
+///
+/// ```compile_fail
+/// use apistos::api_operation;
+///
+/// #[api_operation(no_security, security_scope(name = "api_key", scope = "read"))]
+/// pub(crate) async fn test() -> String {
+///   "test".to_string()
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn api_operation(attr: TokenStream, item: TokenStream) -> TokenStream {
   let attr_args = match NestedMeta::parse_meta_list(attr.into()) {

--- a/apistos-gen/src/operation_attr.rs
+++ b/apistos-gen/src/operation_attr.rs
@@ -5,7 +5,14 @@ use std::collections::BTreeMap;
 
 pub(crate) fn parse_openapi_operation_attrs(attrs: &[NestedMeta]) -> darling::Result<OperationAttr> {
   match OperationAttrInternal::from_list(attrs) {
-    Ok(operation) => Ok(operation.into()),
+    Ok(operation) => {
+      if operation.no_security && !operation.scopes.is_empty() {
+        return Err(darling::Error::custom(
+          "`no_security` and `security_scope` cannot be used together",
+        ));
+      }
+      Ok(operation.into())
+    }
     Err(e) => Err(e),
   }
 }
@@ -21,6 +28,8 @@ struct OperationAttrInternal {
   description: Option<String>,
   #[darling(multiple, rename = "tag")]
   tags: Vec<String>,
+  #[darling(default)]
+  no_security: bool,
   #[darling(multiple, rename = "security_scope")]
   scopes: Vec<SecurityScopes>,
   #[darling(multiple, rename = "error_code")]
@@ -45,6 +54,7 @@ pub(crate) struct OperationAttr {
   pub(crate) summary: Option<String>,
   pub(crate) description: Option<String>,
   pub(crate) tags: Vec<String>,
+  pub(crate) no_security: bool,
   pub(crate) scopes: BTreeMap<String, Vec<String>>,
   pub(crate) error_codes: Vec<u16>,
   pub(crate) consumes: Option<String>,
@@ -61,6 +71,7 @@ impl From<OperationAttrInternal> for OperationAttr {
       summary: value.summary,
       description: value.description.map(|d| d.replace('\n', "\\\n")),
       tags: value.tags,
+      no_security: value.no_security,
       scopes: value
         .scopes
         .into_iter()

--- a/apistos-models/src/paths.rs
+++ b/apistos-models/src/paths.rs
@@ -99,8 +99,8 @@ pub struct Operation {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub deprecated: Option<bool>,
   /// A declaration of which security mechanisms can be used for this operation. The list of values includes alternative security requirement objects that can be used. Only one of the security requirement objects need to be satisfied to authorize a request. To make security optional, an empty security requirement (`{}`) can be included in the array. This definition overrides any declared top-level [`security`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#oasSecurity). To remove a top-level security declaration, an empty array can be used.
-  #[serde(skip_serializing_if = "Vec::is_empty", default)]
-  pub security: Vec<SecurityRequirement>,
+  #[serde(skip_serializing_if = "Option::is_none", default)]
+  pub security: Option<Vec<SecurityRequirement>>,
   /// An alternative `server` array to service this operation. If an alternative `server` object is specified at the Path Item Object or Root level, it will be overridden by this value.
   #[serde(skip_serializing_if = "Vec::is_empty", default)]
   pub servers: Vec<Server>,

--- a/apistos/src/app.rs
+++ b/apistos/src/app.rs
@@ -8,9 +8,12 @@ use actix_web::Error;
 use actix_web::body::MessageBody;
 use actix_web::dev::{HttpServiceFactory, ServiceRequest, ServiceResponse};
 use actix_web::web::{get, resource};
+use apistos_core::ApiComponent;
 use apistos_models::OpenApi;
+use apistos_models::components::Components;
 use apistos_models::paths::{OperationType, Parameter};
 use apistos_models::reference_or::ReferenceOr;
+use apistos_models::security::SecurityRequirement;
 use apistos_plugins::ui::{UIPluginConfig, UIPluginWrapper};
 use indexmap::IndexMap;
 use once_cell::sync::Lazy;
@@ -93,8 +96,42 @@ impl<T> OpenApiWrapper<T> for actix_web::App<T> {
   type Wrapper = App<T>;
 
   fn document(self, spec: Spec) -> Self::Wrapper {
+    let security_requirement_names = spec
+      .securities
+      .iter()
+      .filter_map(|securities| securities.first_key_value().map(|(key, _)| key.clone()))
+      .collect::<Vec<_>>();
+
+    let initial_security_schemes: BTreeMap<_, _> = spec
+      .securities
+      .into_iter()
+      .map(|security| {
+        security
+          .into_iter()
+          .map(|(k, v)| (k, ReferenceOr::Object(v)))
+          .collect::<BTreeMap<_, _>>()
+      })
+      .fold(BTreeMap::new(), |mut a, b| {
+        a.extend(b);
+        a
+      });
+
     let mut open_api_spec = OpenApi {
       info: spec.info,
+      components: if initial_security_schemes.is_empty() {
+        None
+      } else {
+        Some(Components {
+          security_schemes: initial_security_schemes,
+          ..Default::default()
+        })
+      },
+      security: security_requirement_names
+        .into_iter()
+        .map(|name| SecurityRequirement {
+          requirements: BTreeMap::from([(name, vec![])]),
+        })
+        .collect(),
       ..Default::default()
     };
     if !spec.tags.is_empty() {

--- a/apistos/src/spec.rs
+++ b/apistos/src/spec.rs
@@ -1,3 +1,6 @@
+use std::collections::BTreeMap;
+
+use apistos_models::security::{SecurityRequirement, SecurityScheme};
 use schemars::schema::Schema;
 
 use apistos_core::ApiComponent;
@@ -47,4 +50,6 @@ pub struct Spec {
   pub servers: Vec<Server>,
   /// Default parameters to be added to each operation. This only serves for documentation purpose.
   pub default_parameters: Vec<DefaultParameters>,
+  /// Global security
+  pub securities: Vec<BTreeMap<String, SecurityScheme>>,
 }


### PR DESCRIPTION
Currently, if you want to set a default security to all endpoints, you have to change each handler either by setting a `security_scope` or add an `ApiSecurity` derived struct to the handler's arguments.

I believe this is very tedious to do especially when there is a lot of endpoints and I shouldn't have to change my handlers arguments solely for documentation purposes.

This PR introduces: 
- a new `securities` field in the `Spec` struct. This populates the top-level `security` field of the OpenAPI JSON. 
- a new `api_operation` property: `no_security`. This will be used to override `security` field in specific endpoints. **Setting `no_security` and `security_scope` will result in a compilation failure**
- a fix for a bug I encountered while working on this that empties the security field based on arguments passed to the handler even if it does not have a `security_requirement_name` (Commit [`740fbe9f075a647e89d73408845364f72156a3ce`](https://github.com/netwo-io/apistos/commit/740fbe9f075a647e89d73408845364f72156a3ce)).

## Usage

**`securities` field**
```rust
use apistos::{ApiComponent, ApiSecurity, info::Info, spec::Spec};

#[derive(ApiSecurity)]
#[openapi_security(scheme(security_type(http(scheme = "Bearer", bearer_format = "JWT"))))]
pub struct JwtToken;

pub fn get_apistos_spec() -> Spec {
    Spec {
        info: Info {
            title: "My API".to_string(),
            version: "0.1.0".to_string(),
            ..Default::default()
        },
        securities: vec![JwtToken::securities()],
        ..Default::default()
    }
}
```

**`no_security` property of `api_security`**

```rust
#[api_operation(tag = "Login", no_security)]
pub async fn register() -> HttpResponse {
    HttpResponse::Ok().json(serde_json::json!({ "message": "registered" }))
}
```

Thank you for your work on Apistos!